### PR TITLE
Remove delay as a trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 embedded-hal = "0.2.3"
 # # when trying unpushed stuff use
 adafruit-seesaw = { path = "../adafruit-seesaw" }
+nrf52840-hal = "0.12.0"
 
 # [dependencies.adafruit-seesaw]
 # git = "https://github.com/ferrous-systems/adafruit-seesaw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,28 @@ edition = "2018"
 [dependencies]
 embedded-hal = "0.2.3"
 # # when trying unpushed stuff use
+adafruit-seesaw = { path = "../adafruit-seesaw" }
+
+# [dependencies.adafruit-seesaw]
+# git = "https://github.com/ferrous-systems/adafruit-seesaw"
+# branch = "try_shared_bus_crate"
 # adafruit-seesaw = { path = "../adafruit-seesaw" }
 
-[dependencies.adafruit-seesaw]
-git = "https://github.com/ferrous-systems/adafruit-seesaw"
-branch = "try_shared_bus_crate"
-adafruit-seesaw = { path = "../adafruit-seesaw" }
+defmt = "0.2.0"
+defmt-rtt = "0.2.0"
+panic-probe = { version = "0.2.0", features = ["print-defmt"] }
+
+[features]
+# set logging levels here
+default = [
+  "defmt-default",
+  # "dependency-a/defmt-trace",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.3"
+# # when trying unpushed stuff use
+# adafruit-seesaw = { path = "../adafruit-seesaw" }
 
 [dependencies.adafruit-seesaw]
 git = "https://github.com/ferrous-systems/adafruit-seesaw"
-branch = "main"
+branch = "try_shared_bus_crate"
+adafruit-seesaw = { path = "../adafruit-seesaw" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 embedded-hal = "0.2.3"
 # # when trying unpushed stuff use
 adafruit-seesaw = { path = "../adafruit-seesaw" }
-nrf52840-hal = "0.12.0"
+nrf52840-hal = "0.12.2"
 
 # [dependencies.adafruit-seesaw]
 # git = "https://github.com/ferrous-systems/adafruit-seesaw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,8 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.3"
-# # when trying unpushed stuff use
-adafruit-seesaw = { path = "../adafruit-seesaw" }
 nrf52840-hal = "0.12.2"
-
-# [dependencies.adafruit-seesaw]
-# git = "https://github.com/ferrous-systems/adafruit-seesaw"
-# branch = "try_shared_bus_crate"
-# adafruit-seesaw = { path = "../adafruit-seesaw" }
+adafruit-seesaw = { git ="https://github.com/ferrous-systems/adafruit-seesaw", branch = "main"}
 
 defmt = "0.2.0"
 defmt-rtt = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+use defmt::Format; // <- derive attribute
+
 
 use embedded_hal::blocking::{
     i2c::{Read, Write},
@@ -158,7 +160,6 @@ where
 
             // What is this math even? Copy/paste from adafruit code
             let key = ((key) / 8) * 4 + ((key) % 8);
-
             Ok(Some(KeyEvent { key, event }))
         } else {
             Ok(None)
@@ -218,6 +219,7 @@ where
 const MAX_EVENTS_USIZE: usize = 16;
 const MAX_EVENTS_U8: u8 = 16;
 
+#[derive(Format)]
 pub struct Events {
     count: u8,
     events: [KeyEvent; MAX_EVENTS_USIZE]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use embedded_hal::blocking::{
     i2c::{Read, Write},
-    delay::DelayUs,
+    // delay::DelayUs,
 };
 
 pub use adafruit_seesaw::{
@@ -18,18 +18,18 @@ pub use adafruit_seesaw::{
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-pub struct NeoTrellis<I2C, DELAY> {
-    pub seesaw: SeeSaw<I2C, DELAY>,
+pub struct NeoTrellis<I2C> {
+    pub seesaw: SeeSaw<I2C>,
     pub neopixel_settings: NeoPixelSettings,
 }
 
-pub struct NeoPixels<'a, I2C, DELAY> {
-    seesaw: &'a mut SeeSaw<I2C, DELAY>,
+pub struct NeoPixels<'a, I2C> {
+    seesaw: &'a mut SeeSaw<I2C>,
     settings: &'a mut NeoPixelSettings,
 }
 
-pub struct KeyPad<'a, I2C, DELAY> {
-    seesaw: &'a mut SeeSaw<I2C, DELAY>,
+pub struct KeyPad<'a, I2C> {
+    seesaw: &'a mut SeeSaw<I2C>,
 }
 
 pub struct NeoPixelSettings {
@@ -37,12 +37,12 @@ pub struct NeoPixelSettings {
     led_type: ColorOrder,
 }
 
-impl<I2C, DELAY> NeoTrellis<I2C, DELAY>
+impl<I2C> NeoTrellis<I2C>
 where
     I2C: Read + Write,
-    DELAY: DelayUs<u32>,
+    // DELAY: DelayUs<u32>,
 {
-    pub fn new(i2c: I2C, delay: DELAY, address: Option<u8>) -> Result<Self> {
+    pub fn new(i2c: I2C, address: Option<u8>) -> Result<Self> {
         let neopixel_settings = NeoPixelSettings {
             leds_ct: 16,
             led_type: ColorOrder::GRB
@@ -50,7 +50,7 @@ where
 
         let mut seesaw = SeeSaw {
             i2c,
-            delay,
+            // delay,
             address: address.unwrap_or_else(|| 0x2E),
         };
 
@@ -64,28 +64,28 @@ where
         }
     }
 
-    pub fn neopixels(&mut self) -> NeoPixels<I2C, DELAY> {
+    pub fn neopixels(&mut self) -> NeoPixels<I2C> {
         NeoPixels {
             seesaw: &mut self.seesaw,
             settings: &mut self.neopixel_settings,
         }
     }
 
-    pub fn keypad(&mut self) -> KeyPad<I2C, DELAY> {
+    pub fn keypad(&mut self) -> KeyPad<I2C> {
         KeyPad {
             seesaw: &mut self.seesaw,
         }
     }
 
-    pub fn seesaw(&mut self) -> &mut SeeSaw<I2C, DELAY> {
+    pub fn seesaw(&mut self) -> &mut SeeSaw<I2C> {
         &mut self.seesaw
     }
 }
 
-impl<'a, I2C, DELAY> NeoPixels<'a, I2C, DELAY>
+impl<'a, I2C> NeoPixels<'a, I2C>
 where
     I2C: Read + Write,
-    DELAY: DelayUs<u32>,
+    // DELAY: DelayUs<u32>,
 {
     pub fn set_speed(&'a mut self, speed: Speed) -> Result<&'a mut Self> {
         self.seesaw.neopixel_set_speed(speed)?;
@@ -136,10 +136,10 @@ where
     }
 }
 
-impl<'a, I2C, DELAY> KeyPad<'a, I2C, DELAY>
+impl<'a, I2C> KeyPad<'a, I2C>
 where
     I2C: Read + Write,
-    DELAY: DelayUs<u32>,
+    // DELAY: DelayUs<u32>,
 {
     pub fn pending_events(&mut self) -> Result<u8> {
         self.seesaw.keypad_get_count()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@ use defmt::Format; // <- derive attribute
 use embedded_hal::blocking::{
     i2c::{Read, Write},
     // delay::DelayUs,
+    DELAY: Timer<u32>,
 };
+
+use nrf52840_hal::Timer as Timer;
 
 pub use adafruit_seesaw::{
     SeeSaw,
@@ -43,6 +46,7 @@ impl<I2C> NeoTrellis<I2C>
 where
     I2C: Read + Write,
     // DELAY: DelayUs<u32>,
+    DELAY: Timer<u32>,
 {
     pub fn new(i2c: I2C, address: Option<u8>) -> Result<Self> {
         let neopixel_settings = NeoPixelSettings {
@@ -88,6 +92,7 @@ impl<'a, I2C> NeoPixels<'a, I2C>
 where
     I2C: Read + Write,
     // DELAY: DelayUs<u32>,
+    DELAY: Timer<u32>,
 {
     pub fn set_speed(&'a mut self, speed: Speed) -> Result<&'a mut Self> {
         self.seesaw.neopixel_set_speed(speed)?;
@@ -142,6 +147,7 @@ impl<'a, I2C> KeyPad<'a, I2C>
 where
     I2C: Read + Write,
     // DELAY: DelayUs<u32>,
+    DELAY: Timer<u32>,
 {
     pub fn pending_events(&mut self) -> Result<u8> {
         self.seesaw.keypad_get_count()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use defmt::Format; // <- derive attribute
 
 use embedded_hal::blocking::{
     i2c::{Read, Write},
-    // delay::DelayUs,
-    DELAY: Timer<u32>,
+    delay::DelayUs,
+    // DELAY: Timer<u32>,
 };
 
 use nrf52840_hal::Timer as Timer;
@@ -46,9 +46,9 @@ impl<I2C> NeoTrellis<I2C>
 where
     I2C: Read + Write,
     // DELAY: DelayUs<u32>,
-    DELAY: Timer<u32>,
+    // DELAY: Timer<u32>,
 {
-    pub fn new(i2c: I2C, address: Option<u8>) -> Result<Self> {
+    pub fn new<DELAY: DelayUs<u32>>(i2c: I2C, delay: &mut DELAY, address: Option<u8>) -> Result<Self> {
         let neopixel_settings = NeoPixelSettings {
             leds_ct: 16,
             led_type: ColorOrder::GRB
@@ -56,11 +56,10 @@ where
 
         let mut seesaw = SeeSaw {
             i2c,
-            // delay,
             address: address.unwrap_or_else(|| 0x2E),
         };
 
-        if seesaw.status_get_hwid()? == 0x55 {
+        if seesaw.status_get_hwid(delay)? == 0x55 {
             Ok(Self {
                 seesaw,
                 neopixel_settings,
@@ -91,8 +90,8 @@ where
 impl<'a, I2C> NeoPixels<'a, I2C>
 where
     I2C: Read + Write,
-    // DELAY: DelayUs<u32>,
-    DELAY: Timer<u32>,
+
+    // DELAY: Timer<u32>,
 {
     pub fn set_speed(&'a mut self, speed: Speed) -> Result<&'a mut Self> {
         self.seesaw.neopixel_set_speed(speed)?;
@@ -146,18 +145,18 @@ where
 impl<'a, I2C> KeyPad<'a, I2C>
 where
     I2C: Read + Write,
-    // DELAY: DelayUs<u32>,
-    DELAY: Timer<u32>,
+
+    // DELAY: Timer<u32>,
 {
-    pub fn pending_events(&mut self) -> Result<u8> {
-        self.seesaw.keypad_get_count()
+    pub fn pending_events<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<u8> {
+        self.seesaw.keypad_get_count(delay)
     }
 
-    pub fn get_event(&mut self) -> Result<Option<KeyEvent>> {
-        if self.pending_events()? > 0 {
+    pub fn get_event<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<Option<KeyEvent>> {
+        if self.pending_events(delay)? > 0 {
             let mut evt_raw = [0u8; 1];
 
-            self.seesaw.keypad_read_raw(&mut evt_raw)?;
+            self.seesaw.keypad_read_raw(&mut evt_raw, delay)?;
 
             let event = evt_raw[0] & 0b0000_0011;
             let event = Edge::from_u8(event)?;
@@ -172,9 +171,9 @@ where
         }
     }
 
-    pub fn get_events(&mut self) -> Result<Events> {
+    pub fn get_events<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<Events> {
         use core::cmp::min;
-        let ct = self.pending_events()?;
+        let ct = self.pending_events(delay)?;
         let mut retval = Events::new();
 
         if ct == 0 {
@@ -184,7 +183,7 @@ where
         let mut evt_raw = [0u8; MAX_EVENTS_USIZE];
         let ct = min(ct, MAX_EVENTS_U8);
 
-        self.seesaw.keypad_read_raw(&mut evt_raw[..ct as usize])?;
+        self.seesaw.keypad_read_raw(&mut evt_raw[..ct as usize], delay)?;
 
         for i in 0..(ct as usize) {
             let event = evt_raw[i] & 0b0000_0011;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use defmt::Format; // <- derive attribute
 use embedded_hal::blocking::{
     i2c::{Read, Write},
     delay::DelayUs,
-    // DELAY: Timer<u32>,
 };
 
 use nrf52840_hal::Timer as Timer;
@@ -45,8 +44,6 @@ pub struct NeoPixelSettings {
 impl<I2C> NeoTrellis<I2C>
 where
     I2C: Read + Write,
-    // DELAY: DelayUs<u32>,
-    // DELAY: Timer<u32>,
 {
     pub fn new<DELAY: DelayUs<u32>>(i2c: I2C, delay: &mut DELAY, address: Option<u8>) -> Result<Self> {
         let neopixel_settings = NeoPixelSettings {
@@ -91,7 +88,6 @@ impl<'a, I2C> NeoPixels<'a, I2C>
 where
     I2C: Read + Write,
 
-    // DELAY: Timer<u32>,
 {
     pub fn set_speed(&'a mut self, speed: Speed) -> Result<&'a mut Self> {
         self.seesaw.neopixel_set_speed(speed)?;
@@ -146,7 +142,6 @@ impl<'a, I2C> KeyPad<'a, I2C>
 where
     I2C: Read + Write,
 
-    // DELAY: Timer<u32>,
 {
     pub fn pending_events<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<u8> {
         self.seesaw.keypad_get_count(delay)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use embedded_hal::blocking::{
     delay::DelayUs,
 };
 
-use nrf52840_hal::Timer as Timer;
 
 pub use adafruit_seesaw::{
     SeeSaw,


### PR DESCRIPTION
Removes delay as a trait so shared-bus crate can get used.
This is preparation for the [knurling sessions minesweeper game](https://knurling-books.ferrous-systems.com/neotrellis/neotrellis.html).
3 PRs belong together. Merge in this order:

- [x]  https://github.com/ferrous-systems/adafruit-seesaw/pull/1
- [x] this one
- [ ] https://github.com/knurling-rs/neotrellis-driver/pull/1